### PR TITLE
fix: Handle missing SESSION_SECRET and update Docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ A pre-built image is also available on Docker Hub, which can be pulled directly.
 docker pull anasrudin/streamflow:latest
 ```
 
+**Note:** Due to recent changes to handle session management more securely (as of November 21, 2023), the `anasrudin/streamflow:latest` image on Docker Hub needs to be rebuilt and pushed by the maintainer. If you have pulled the image before this update, please ensure you pull the newest version once it's updated, or consider building the image locally for the latest changes. You can check the "Last pushed" date on [Docker Hub](https://hub.docker.com/r/anasrudin/streamflow/tags).
+
 **Alternatively, Build the Docker Image Locally:**
 
 First, build the Docker image using the provided `Dockerfile`. Make sure you have Docker installed on your system.
@@ -170,19 +172,36 @@ First, build the Docker image using the provided `Dockerfile`. Make sure you hav
 docker build -t streamflow .
 ```
 
+**Note:** If you are rebuilding the image after recent changes (around November 21, 2023) related to session secret handling, ensure you have the latest code changes pulled from the repository.
+
 **Run the Docker Container:**
 
 Once the image is built or pulled, you can run it as a container.
 
 ```bash
-docker run -d -p 7575:7575 --name streamflow-app anasrudin/streamflow:latest
+docker run -d -p 7575:7575 \
+  -e SESSION_SECRET="your_very_strong_and_unique_secret_here" \
+  --name streamflow-app anasrudin/streamflow:latest
 ```
 
 Explanation of the command:
 - `-d`: Runs the container in detached mode (in the background).
 - `-p 7575:7575`: Maps port 7575 on your host to port 7575 in the container. If you changed the port in the `.env` file, adjust the host port accordingly (e.g., `-p YOUR_HOST_PORT:CONTAINER_PORT`).
+- `-e SESSION_SECRET="your_very_strong_and_unique_secret_here"`: Sets the session secret. **Important:** Replace `"your_very_strong_and_unique_secret_here"` with a long, random string. This is crucial for security. If not provided, the application will generate a temporary, less secure secret and issue a warning.
 - `--name streamflow-app`: Assigns a name to your container for easier management.
 - `anasrudin/streamflow:latest`: Specifies the image to use from Docker Hub. If you built it locally, you can use the local image name (e.g., `streamflow`).
+
+**Important: Setting the `SESSION_SECRET`**
+
+For security reasons, it is crucial to set a `SESSION_SECRET` environment variable when running the container in production, or even for persistent personal use. This secret is used to sign session cookies.
+
+You can generate a strong secret using a command like:
+```bash
+openssl rand -hex 32
+```
+Use the output of this command as your `SESSION_SECRET`.
+
+If you do not provide a `SESSION_SECRET` via the `-e` flag, the application will automatically generate a temporary secret for the current session. While this allows the application to run, it is **not secure for production** as the secret will change each time the container restarts, invalidating all previous sessions. A warning will be logged to the console in such cases.
 
 **Accessing the Application:**
 

--- a/app.js
+++ b/app.js
@@ -8,6 +8,7 @@ const multer = require('multer');
 const fs = require('fs');
 const csrf = require('csrf');
 const { v4: uuidv4 } = require('uuid');
+const crypto = require('crypto');
 const session = require('express-session');
 const SQLiteStore = require('connect-sqlite3')(session);
 const bcrypt = require('bcrypt');
@@ -104,13 +105,25 @@ app.locals.helpers = {
     return `${hours}:${minutes}:${secs}`;
   }
 };
+
+let sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret) {
+  sessionSecret = crypto.randomBytes(64).toString('hex');
+  console.warn(`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
+  console.warn(`!!! WARNING: SESSION_SECRET environment variable not set.                  !!!`);
+  console.warn(`!!! A temporary secret has been generated for this session.                !!!`);
+  console.warn(`!!! This is NOT secure for production environments.                        !!!`);
+  console.warn(`!!! Please set a strong, unique SESSION_SECRET environment variable.       !!!`);
+  console.warn(`!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!`);
+}
+
 app.use(session({
   store: new SQLiteStore({
     db: 'sessions.db',
     dir: './db/',
     table: 'sessions'
   }),
-  secret: process.env.SESSION_SECRET,
+  secret: sessionSecret,
   resave: false,
   saveUninitialized: false,
   cookie: {


### PR DESCRIPTION
This commit addresses an issue where the application would crash if the SESSION_SECRET environment variable was not set, particularly when running in Docker.

Changes:
- Modified `app.js` to:
  - Require the `crypto` module.
  - Check for the `SESSION_SECRET` environment variable.
  - If not set, generate a temporary, cryptographically strong secret.
  - Log a prominent warning to the console when a temporary secret is used, advising you to set a proper secret for production.
- Updated `README.md` in the "Running with Docker" section to:
  - Instruct you on how to set the `SESSION_SECRET` using the `-e` flag in the `docker run` command.
  - Explain the importance of setting a strong, unique secret for production environments.
  - Detail how to generate a strong secret (e.g., using `openssl rand -hex 32`).
  - Add notes advising that the `anasrudin/streamflow:latest` image on Docker Hub will need to be updated by the maintainer due to these changes, and that local builds should use the latest code. The date November 21, 2023 is used as a reference for these changes.