### PR TITLE
fix: Implement data persistence for Docker deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,13 @@ RUN npm install
 # Copy the rest of the application code
 COPY . .
 
+# Define mount points for persistent data
+VOLUME /usr/src/app/db
+VOLUME /usr/src/app/public/uploads/videos
+VOLUME /usr/src/app/public/uploads/thumbnails
+VOLUME /usr/src/app/public/uploads/avatars
+VOLUME /usr/src/app/logs
+
 # Expose the application port
 EXPOSE 7575
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ A pre-built image is also available on Docker Hub, which can be pulled directly.
 docker pull anasrudin/streamflow:latest
 ```
 
-**Note:** Due to recent changes to handle session management more securely (as of November 21, 2023), the `anasrudin/streamflow:latest` image on Docker Hub needs to be rebuilt and pushed by the maintainer. If you have pulled the image before this update, please ensure you pull the newest version once it's updated, or consider building the image locally for the latest changes. You can check the "Last pushed" date on [Docker Hub](https://hub.docker.com/r/anasrudin/streamflow/tags).
+**Note:** Due to recent changes (as of November 21, 2023) to handle session management more securely and to define proper data persistence volumes in the Dockerfile, the `anasrudin/streamflow:latest` image on Docker Hub needs to be rebuilt and pushed by the maintainer. These changes ensure your data (database, uploads, etc.) is correctly saved outside the container when using the volume mount instructions. If you have pulled the image before this update, please ensure you pull the newest version once it's updated, or consider building the image locally for the latest changes. You can check the "Last pushed" date on [Docker Hub](https://hub.docker.com/r/anasrudin/streamflow/tags).
 
 **Alternatively, Build the Docker Image Locally:**
 
@@ -172,15 +172,21 @@ First, build the Docker image using the provided `Dockerfile`. Make sure you hav
 docker build -t streamflow .
 ```
 
-**Note:** If you are rebuilding the image after recent changes (around November 21, 2023) related to session secret handling, ensure you have the latest code changes pulled from the repository.
+**Note:** If you are rebuilding the image after recent changes (around November 21, 2023) related to session secret handling and data persistence volumes, ensure you have the latest code changes (including the updated `Dockerfile`) pulled from the repository.
 
 **Run the Docker Container:**
 
 Once the image is built or pulled, you can run it as a container.
 
 ```bash
-docker run -d -p 7575:7575 \
+docker run -d \
+  -p 7575:7575 \
   -e SESSION_SECRET="your_very_strong_and_unique_secret_here" \
+  -v ./streamflow_data/db:/usr/src/app/db \
+  -v ./streamflow_data/uploads/videos:/usr/src/app/public/uploads/videos \
+  -v ./streamflow_data/uploads/thumbnails:/usr/src/app/public/uploads/thumbnails \
+  -v ./streamflow_data/uploads/avatars:/usr/src/app/public/uploads/avatars \
+  -v ./streamflow_data/logs:/usr/src/app/logs \
   --name streamflow-app anasrudin/streamflow:latest
 ```
 
@@ -188,8 +194,15 @@ Explanation of the command:
 - `-d`: Runs the container in detached mode (in the background).
 - `-p 7575:7575`: Maps port 7575 on your host to port 7575 in the container. If you changed the port in the `.env` file, adjust the host port accordingly (e.g., `-p YOUR_HOST_PORT:CONTAINER_PORT`).
 - `-e SESSION_SECRET="your_very_strong_and_unique_secret_here"`: Sets the session secret. **Important:** Replace `"your_very_strong_and_unique_secret_here"` with a long, random string. This is crucial for security. If not provided, the application will generate a temporary, less secure secret and issue a warning.
+- `-v ./streamflow_data/db:/usr/src/app/db`: Mounts the `./streamflow_data/db` directory from your host to `/usr/src/app/db` in the container for database persistence.
+- `-v ./streamflow_data/uploads/videos:/usr/src/app/public/uploads/videos`: Mounts video uploads.
+- `-v ./streamflow_data/uploads/thumbnails:/usr/src/app/public/uploads/thumbnails`: Mounts video thumbnails.
+- `-v ./streamflow_data/uploads/avatars:/usr/src/app/public/uploads/avatars`: Mounts user avatars.
+- `-v ./streamflow_data/logs:/usr/src/app/logs`: Mounts application logs.
 - `--name streamflow-app`: Assigns a name to your container for easier management.
 - `anasrudin/streamflow:latest`: Specifies the image to use from Docker Hub. If you built it locally, you can use the local image name (e.g., `streamflow`).
+
+Before running the command, you might want to create the directories on your host machine (e.g., `mkdir -p ./streamflow_data/db ./streamflow_data/uploads/videos ./streamflow_data/uploads/thumbnails ./streamflow_data/uploads/avatars ./streamflow_data/logs`). If you don't, Docker will create them for you, but they will be owned by `root`. Creating them beforehand allows you to manage permissions more easily.
 
 **Important: Setting the `SESSION_SECRET`**
 
@@ -202,6 +215,14 @@ openssl rand -hex 32
 Use the output of this command as your `SESSION_SECRET`.
 
 If you do not provide a `SESSION_SECRET` via the `-e` flag, the application will automatically generate a temporary secret for the current session. While this allows the application to run, it is **not secure for production** as the secret will change each time the container restarts, invalidating all previous sessions. A warning will be logged to the console in such cases.
+
+**Data Persistence**
+
+The `docker run` command above uses volume mounts (`-v` flags) to store application data (database, uploaded videos, thumbnails, avatars, and logs) on your host machine in the `./streamflow_data` directory (or a path you specify). This is crucial because:
+- It ensures your data persists even if you stop or remove the Docker container.
+- Without these volume mounts, all data, including your streams, gallery, and user settings, would be lost when the container is removed.
+
+Make sure the host paths you specify for the volumes (e.g., `./streamflow_data/db`) exist or that Docker has permission to create them.
 
 **Accessing the Application:**
 


### PR DESCRIPTION
This commit resolves a critical bug where application data was not persisting when running StreamFlow inside a Docker container. This was due to data being stored in the container's ephemeral filesystem.

Changes:
- **Dockerfile:**
  - Added `VOLUME` instructions for the following directories:
    - `/usr/src/app/db` (database files)
    - `/usr/src/app/public/uploads/videos` (uploaded videos)
    - `/usr/src/app/public/uploads/thumbnails` (video thumbnails)
    - `/usr/src/app/public/uploads/avatars` (user avatars)
    - `/usr/src/app/logs` (application logs)
  - These instructions define mount points for persistent storage.

- **README.md:**
  - Updated the `docker run` command example to include volume mounts (`-v` flags) for all the directories listed above, mapping them to host directories (e.g., `./streamflow_data/*`).
  - Added a detailed explanation of each volume mount.
  - Included advice for you to pre-create host directories for volumes to manage permissions effectively.
  - Added a new "Data Persistence" section explaining the importance of these volumes for ensuring data is not lost when containers are stopped or removed.
  - Updated the notes regarding the `anasrudin/streamflow:latest` Docker Hub image, indicating it needs to be rebuilt and re-uploaded by the maintainer to incorporate these data persistence changes.